### PR TITLE
Fix non-resetting minor version

### DIFF
--- a/release.py
+++ b/release.py
@@ -67,6 +67,7 @@ class Version:
 
     def bump_major(self):
         self.major += 1
+        self.minor = 0
 
     def bump_minor(self):
         self.minor += 1


### PR DESCRIPTION
Fixes `Version.bump_major` method  in `release.py` to reset minor version to `'0'` when major
version is bumped