### PR TITLE
Fix failing api post for non-problem release

### DIFF
--- a/release.py
+++ b/release.py
@@ -99,7 +99,7 @@ class Release:
 
     def get_body(self, path):
         if path == None:
-            return None
+            return ""
         return f"[{self.name}](https://github.com/saulmaldonado/ds-and-algorithms/tree/main/{path})"
 
     def new_release(self):


### PR DESCRIPTION
Github API does not accept null for body on a release post request. This
changes the `Release.get_body` method to return an empty string `""` if the
path is `None`