### PR TITLE
divide two integers

### DIFF
--- a/bit-manipulation/divide-two-integers/README.md
+++ b/bit-manipulation/divide-two-integers/README.md
@@ -1,0 +1,115 @@
+# Divide Two Integers
+
+## Difficulty
+
+![Medium](https://img.shields.io/badge/medium-ef6c00?style=for-the-badge&logoColor=white)
+
+## Problem:
+
+Given two integers dividend and divisor, divide two integers without using multiplication, division, and mod operator.
+
+Return the quotient after dividing dividend by divisor.
+
+The integer division should truncate toward zero, which means losing its fractional part. For example, truncate(8.345) = 8 and truncate(-2.7335) = -2.
+
+Note:
+
+- Assume we are dealing with an environment that could only store integers within the 32-bit signed integer range: [−231, 231 − 1]. For this problem, assume that your function returns 231 − 1 when the division result overflows.
+
+### Example 1:
+
+```
+Input: dividend = 10, divisor = 3
+Output: 3
+Explanation: 10/3 = truncate(3.33333..) = 3.
+```
+
+### Example 2:
+
+```
+Input: dividend = 7, divisor = -3
+Output: -2
+Explanation: 7/-3 = truncate(-2.33333..) = -2.
+```
+
+### Example 3:
+
+```
+Input: dividend = 0, divisor = 1
+Output: 0
+```
+
+### Example 4:
+
+```
+Input: dividend = 1, divisor = 1
+Output: 1
+```
+
+### Constraints
+
+`-2^31 <= dividend, divisor <= 2^31 - 1`
+
+`divisor != 0`
+
+<details>
+  <summary>Solutions (Click to expand)</summary>
+
+### Explanation
+
+#### Subtracting and Bit Shifting
+
+If we think of division as how many times we can subtract the divisor from the divided without going negative, we can find the truncated quotient
+
+```
+dividend = 10 divisor = 3
+
+10 - 3 = 7 // quotient = 1
+
+7 - 3 = 4 // quotient = 2
+
+4 - 3 = 1 // quotient = 3
+```
+
+If we use a solution where we subtract `divisor` from `dividend` until dividend become `<= 0`, it would take at most `O(N)` operations where `N` is dividend. This means `2^31 - 1` / `1` would take `2^31 - 1` operations. We can come up with a logarithmic solution where instead of incrementing our quotient by `1`, we can double it using bit shifting until right before the difference becomes less than `0`.
+
+```
+dividend = 10 divisor = 3
+
+10 - (3 << 0) = 7 // quotient 1
+
+10 - (3 << 1) = 4 // quotient 2
+
+10 - (3 << 2) = -2 // difference is negative, take the last quotient
+
+10 - 3 * 2 = 4
+```
+
+We would then repeat the operations of the remainder
+
+```
+divided = 4 divisor = 3
+
+4 - (3 << 0) = 1 // quotient 1
+
+4 - (3 << 1) = -1 // difference is negative, take the last quotient
+
+4 - 3 = 1
+```
+
+Once we can no longer divide the dividend by the divisor we can return the sum of all the quotients we've calculated.
+
+```
+10 - 3 * 2 = 4 // quotient 2
+4 - 3 * 1 = 1 // quotient 1
+```
+
+Time: `O(log N ^ 2)`
+
+Space: `O(1)`
+
+- [JavaScript](./divide-two-integers.js)
+- [TypeScript](./divide-two-integers.ts)
+- [Java](./divide-two-integers.java)
+- [Go](./divide-two-integers.go)
+</details>

--- a/bit-manipulation/divide-two-integers/divide-two-integers.go
+++ b/bit-manipulation/divide-two-integers/divide-two-integers.go
@@ -1,0 +1,47 @@
+package dividetwointegers
+
+import "math"
+
+func divide(dividend int, divisor int) int {
+	if dividend == math.MinInt32 && divisor == -1 { // result in 2,147,483,648 which truncates to 2,147,483,647
+		return (1 << 31) - 1
+	}
+
+	sign := 1
+
+	if dividend < 0 {
+		sign *= -1
+	}
+
+	if divisor < 0 {
+		sign *= -1
+	}
+
+	dvd := dividend
+
+	if dvd < 0 {
+		dvd *= -1
+	}
+
+	dvr := divisor
+
+	if dvr < 0 {
+		dvr *= -1
+	}
+
+	res := 0
+
+	for dvd-dvr >= 0 {
+		x := 0
+
+		for dvd-(dvr<<x<<1) >= 0 {
+			x++
+		}
+
+		res += 1 << x
+
+		dvd -= dvr << x
+	}
+
+	return res * sign
+}

--- a/bit-manipulation/divide-two-integers/divide-two-integers.java
+++ b/bit-manipulation/divide-two-integers/divide-two-integers.java
@@ -1,0 +1,35 @@
+class Solution {
+  public int divide(int dividend, int divisor) {
+    if (dividend == 1 << 31 && divisor == -1) {
+      return (1 << 31) - 1;
+    }
+
+    int sign = 1;
+
+    if (dividend < 0) {
+      sign *= -1;
+    }
+
+    if (divisor < 0) {
+      sign *= -1;
+    }
+
+    int dvd = Math.abs(dividend);
+    int dvr = Math.abs(divisor);
+    int res = 0;
+
+    while (dvd - dvr >= 0) {
+      int x = 0;
+
+      while (dvd - (dvr << x << 1) >= 0) {
+        x++;
+      }
+
+      res += 1 << x;
+      dvd -= dvr << x;
+    }
+
+    return res * sign;
+  }
+
+}

--- a/bit-manipulation/divide-two-integers/divide-two-integers.js
+++ b/bit-manipulation/divide-two-integers/divide-two-integers.js
@@ -1,0 +1,34 @@
+function divide(dividend, divisor) {
+  // result in 2,147,483,648 which truncates to 2,147,483,647
+  if (dividend === 1 << 31 && divisor === -1) {
+    return ~~((1 << 31) - 1);
+  }
+
+  let sign = 1;
+
+  if (dividend < 0) {
+    sign *= -1;
+  }
+
+  if (divisor < 0) {
+    sign *= -1;
+  }
+
+  let dvd = Math.abs(dividend);
+  let dvr = Math.abs(divisor);
+
+  let res = 0;
+
+  while (dvd - dvr >= 0) {
+    let x = 0;
+
+    while (~~(dvd - ((dvr << x) << 1)) >= 0) {
+      x++;
+    }
+
+    res += 1 << x;
+    dvd = ~~(dvd - (dvr << x));
+  }
+
+  return ~~(res * sign);
+}

--- a/bit-manipulation/divide-two-integers/divide-two-integers.ts
+++ b/bit-manipulation/divide-two-integers/divide-two-integers.ts
@@ -1,0 +1,33 @@
+function divide(dividend: number, divisor: number): number {
+  if (dividend === 1 << 31 && divisor === -1) {
+    return ~~((1 << 31) - 1);
+  }
+
+  let sign = 1;
+
+  if (dividend < 0) {
+    sign *= -1;
+  }
+
+  if (divisor < 0) {
+    sign *= -1;
+  }
+
+  let dvd = Math.abs(dividend);
+  let dvr = Math.abs(divisor);
+
+  let res = 0;
+
+  while (dvd - dvr >= 0) {
+    let x = 0;
+
+    while (~~(dvd - ((dvr << x) << 1)) >= 0) {
+      x++;
+    }
+
+    res += 1 << x;
+    dvd = ~~(dvd - (dvr << x));
+  }
+
+  return ~~(res * sign);
+}


### PR DESCRIPTION
# Title

Divide Two Integers

# Topic

Bit Manipulation

# Description


Given two integers dividend and divisor, divide two integers without using multiplication, division, and mod operator.

Return the quotient after dividing dividend by divisor.

The integer division should truncate toward zero, which means losing its fractional part. For example, truncate(8.345) = 8 and truncate(-2.7335) = -2.

Note:

- Assume we are dealing with an environment that could only store integers within the 32-bit signed integer range: [−231, 231 − 1]. For this problem, assume that your function returns 231 − 1 when the division result overflows.

# Checklist

## README

- [x] Follows [PROBLEM-TEMPLATE](https://github.com/saulmaldonado/ds-and-algorithms/blob/main/PROBLEM-TEMPLATE.md)

## Solutions

- [x] Go

- [x] Java

- [x] JavaScript

- [x] TypeScript
