### PR TITLE
Fix file path matching regex

### DIFF
--- a/release.py
+++ b/release.py
@@ -39,7 +39,7 @@ class PullRequest:
 
         for filename in filenames:
             match = re.match(
-                r"(?P<topic>[\w]+)\/(?P<name>[\w!-)\-]+)\/(?P<filename>README\.md|\2(?:\.js|\.ts|\.go|\.java))",
+                r"(?P<topic>[\w!-)\-]+)\/(?P<name>[\w!-)\-]+)\/(?P<filename>README\.md|\2(?:\.js|\.ts|\.go|\.java))",
                 filename,
             )
             if match is not None:


### PR DESCRIPTION
Fixes file path matching regex to match with multi-word topics and match with those paths. This will fix the empty body issue on newer releases.