### PR TITLE
vowel spellchecker

### DIFF
--- a/strings/vowel-spellchecker/README.md
+++ b/strings/vowel-spellchecker/README.md
@@ -1,0 +1,108 @@
+# Vowel Spellchecker
+
+## Difficulty
+
+![Medium](https://img.shields.io/badge/medium-ef6c00?style=for-the-badge&logoColor=white)
+
+## Problem
+
+Given a wordlist, we want to implement a spellchecker that converts a query word into a correct word.
+
+For a given query word, the spell checker handles two categories of spelling mistakes:
+
+- Capitalization: If the query matches a word in the wordlist (case-insensitive), then the query word is returned with the same case as the case in the wordlist.
+  - Example: wordlist = ["yellow"], query = "YellOw": correct = "yellow"
+  - Example: wordlist = ["Yellow"], query = "yellow": correct = "Yellow"
+  - Example: wordlist = ["yellow"], query = "yellow": correct = "yellow"
+- Vowel Errors: If after replacing the vowels ('a', 'e', 'i', 'o', 'u') of the query word with any vowel individually, it matches a word in the wordlist (case-insensitive), then the query word is returned with the same case as the match in the wordlist.
+  - Example: wordlist = ["YellOw"], query = "yollow": correct = "YellOw"
+  - Example: wordlist = ["YellOw"], query = "yeellow": correct = "" (no match)
+  - Example: wordlist = ["YellOw"], query = "yllw": correct = "" (no match)
+
+In addition, the spell checker operates under the following precedence rules:
+
+- When the query exactly matches a word in the wordlist (case-sensitive), you should return the same word back.
+- When the query matches a word up to capitlization, you should return the first such match in the wordlist.
+- When the query matches a word up to vowel errors, you should return the first such match in the wordlist.
+- If the query has no matches in the wordlist, you should return the empty string.
+
+Given some queries, return a list of words answer, where answer[i] is the correct word for query = queries[i].
+
+### Example 1
+
+```
+Input: wordlist = ["KiTe","kite","hare","Hare"], queries = ["kite","Kite","KiTe","Hare","HARE","Hear","hear","keti","keet","keto"]
+Output: ["kite","KiTe","KiTe","Hare","hare","","","KiTe","","KiTe"]
+```
+
+### Constraints
+
+`1 <= wordlist.length <= 5000`
+
+`1 <= queries.length <= 5000`
+
+`1 <= wordlist[i].length <= 7`
+
+`1 <= queries[i].length <= 7`
+
+`All strings in wordlist and queries consist only of english letters.`
+
+<details>
+  <summary>Solutions (Click to expand)</summary>
+
+### Explanation
+
+#### 3 Maps
+
+##### Intuition
+
+For every `word` in `wordlist` there are three three possbile ways we can match with a `query`.
+
+1. The `word` matches the `query` exactly
+2. The `word` matches the `query` case-insensitive matching
+3. The `word` match the `query` by matching a vowel with any vowel and using case insensitive matching
+
+This mean every string can be in 3 different states, one where the string is unchanged, one where the string is entirely one casing, and one where the string is entirly one casing and all of the vowel are replaces with wildcards `"*"`. If we can generate all 3 states of the word and map the word to its original state then we can try to match every `query` with one of the 3 states for every word. The first one we can match with will be the found `word`.
+
+##### Implementation
+
+We'll use 3 Maps to a state of a `word` with its original. The first one will be its original untouched state. Since this maps a `word` with itself we can use a Set instead for this
+
+```
+set = new Set(words);
+```
+
+The second one will be the case insensitve state. To do this we'll turn the entire `word` to its lower case version and map it with the original word
+
+```
+map[word.toLowerCase()] = word
+```
+
+The third one well the case insensitive with wildcard vowels state. To do this we'll turn the entire `word` to its lower case version and replace all of the vowels with `"*"` which can be done using a regex replacement or a helper method. This will be mapped to its original `word`
+
+```
+map[word.toLowerCase().replaceAll("[aeiou]", "*")] = word
+```
+
+Now to match every `query` with a state of the word, we'll need to turn every `query` into one of the three states as well. For example if we want to compare a `query` with a case-insensitive `word` we'll need to convert `query` to its case-insensitive version before comparing. To do this efficiently we can have separate helper methods that will convert a string into one of the three states.
+
+```
+word = "AbC"
+
+"AbC" = exact(word)
+"abc" = caseInsensitive(word)
+"*bc" = errorVowels(word)
+```
+
+If we match a `query` with one of the states of the `word` we will take the original word and return that as the match
+
+Time: `O(N * M)` Where `N` is the total number of strings in `wordlist` and `queries` and `M` is the average length of the word
+
+Space: `O(3 * W)` Where `W` is the length of `wordlist`
+
+- [JavaScript](./vowel-spellchecker.js)
+- [TypeScript](./vowel-spellchecker.ts)
+- [Java](./vowel-spellchecker.java)
+- [Go](./vowel-spellchecker.go)
+
+</details>

--- a/strings/vowel-spellchecker/vowel-spellchecker.go
+++ b/strings/vowel-spellchecker/vowel-spellchecker.go
@@ -1,0 +1,57 @@
+package vowelspellchecker
+
+import (
+	"regexp"
+	"strings"
+)
+
+func spellchecker(wordlist []string, queries []string) []string {
+	words := make(map[string]bool)
+
+	for _, w := range wordlist {
+		words[w] = true
+	}
+
+	lowered := make(map[string]string)
+	noVowels := make(map[string]string)
+
+	for _, w := range wordlist {
+		l := caseInsensitive(w)
+		e := errorVowels(w)
+		if _, ok := lowered[l]; !ok {
+			lowered[l] = w
+		}
+		if _, ok := noVowels[e]; !ok {
+			noVowels[e] = w
+		}
+	}
+
+	for i := range queries {
+		word := queries[i]
+
+		if _, ok := words[word]; ok {
+			continue
+		}
+
+		lower := caseInsensitive(word)
+		noVowel := errorVowels(word)
+
+		if _, ok := lowered[lower]; ok {
+			queries[i] = lowered[lower]
+		} else if _, ok := noVowels[noVowel]; ok {
+			queries[i] = noVowels[noVowel]
+		} else {
+			queries[i] = ""
+		}
+	}
+	return queries
+}
+
+func caseInsensitive(word string) string {
+	return strings.ToLower(word)
+}
+
+func errorVowels(word string) string {
+	pattern := regexp.MustCompile("[aeiou]")
+	return pattern.ReplaceAllString(strings.ToLower(word), "*")
+}

--- a/strings/vowel-spellchecker/vowel-spellchecker.java
+++ b/strings/vowel-spellchecker/vowel-spellchecker.java
@@ -1,0 +1,40 @@
+class Solution {
+  public String[] spellchecker(String[] wordlist, String[] queries) {
+    Set<String> words = new HashSet<>(Arrays.asList(wordlist));
+    Map<String, String> lowered = new HashMap<>();
+    Map<String, String> noVowels = new HashMap<>();
+
+    for (String word : wordlist) {
+      lowered.putIfAbsent(caseInsensitive(word), word);
+      noVowels.putIfAbsent(errorVowels(word), word);
+    }
+
+    for (int i = 0; i < queries.length; i++) {
+      String word = queries[i];
+
+      if (words.contains(word)) {
+        continue;
+      }
+
+      String lower = caseInsensitive(word);
+      String noVowel = errorVowels(word);
+
+      if (lowered.containsKey(lower)) {
+        queries[i] = lowered.get(lower);
+      } else if (noVowels.containsKey(noVowel)) {
+        queries[i] = noVowels.get(noVowel);
+      } else {
+        queries[i] = "";
+      }
+    }
+    return queries;
+  }
+
+  private String caseInsensitive(String word) {
+    return word.toLowerCase();
+  }
+
+  private String errorVowels(String word) {
+    return word.toLowerCase().replaceAll("[aeiou]", "*");
+  }
+}

--- a/strings/vowel-spellchecker/vowel-spellchecker.js
+++ b/strings/vowel-spellchecker/vowel-spellchecker.js
@@ -1,0 +1,62 @@
+/**
+ * @param {string[]} wordlist
+ * @param {string[]} queries
+ * @return {string[]}
+ */
+function spellchecker(wordlist, queries) {
+  const words = new Set(wordlist);
+  const lowered = {};
+  const noVowels = {};
+
+  for (let i = 0; i < wordlist.length; i++) {
+    const word = wordlist[i];
+    const l = caseInsensitive(word);
+    const e = errorVowels(word);
+
+    if (!lowered[l]) {
+      lowered[l] = word;
+    }
+
+    if (!noVowels[e]) {
+      noVowels[e] = word;
+    }
+  }
+
+  for (let i = 0; i < queries.length; i++) {
+    const word = queries[i];
+
+    if (words.has(word)) {
+      continue;
+    }
+
+    const lower = caseInsensitive(word);
+    const noVowel = errorVowels(word);
+
+    if (lowered[lower]) {
+      queries[i] = lowered[lower];
+    } else if (noVowels[noVowel]) {
+      queries[i] = noVowels[noVowel];
+    } else {
+      queries[i] = '';
+    }
+  }
+  return queries;
+}
+
+/**
+ *
+ * @param {string} word
+ * @returns {string}
+ */
+function caseInsensitive(word) {
+  return word.toLowerCase();
+}
+
+/**
+ *
+ * @param {string} word
+ * @returns {string}
+ */
+function errorVowels(word) {
+  return word.toLowerCase().replace(/[aeiou]/g, '*');
+}

--- a/strings/vowel-spellchecker/vowel-spellchecker.ts
+++ b/strings/vowel-spellchecker/vowel-spellchecker.ts
@@ -1,0 +1,52 @@
+function spellchecker(wordlist: string[], queries: string[]): string[] {
+  const words: Set<string> = new Set(wordlist);
+  const lowered: Record<string, string> = {};
+  const noVowels: Record<string, string> = {};
+
+  for (let i = 0; i < wordlist.length; i++) {
+    const word: string = wordlist[i];
+    const l: string = caseInsensitive(word);
+    const e: string = errorVowels(word);
+
+    if (!lowered[l]) {
+      lowered[l] = word;
+    }
+
+    if (!noVowels[e]) {
+      noVowels[e] = word;
+    }
+  }
+
+  for (let i = 0; i < queries.length; i++) {
+    const word: string = queries[i];
+
+    if (words.has(word)) {
+      continue;
+    }
+
+    const lower: string = caseInsensitive(word);
+    const noVowel: string = errorVowels(word);
+
+    if (lowered[lower]) {
+      queries[i] = lowered[lower];
+    } else if (noVowels[noVowel]) {
+      queries[i] = noVowels[noVowel];
+    } else {
+      queries[i] = '';
+    }
+  }
+  return queries;
+}
+
+function caseInsensitive(word: string): string {
+  return word.toLowerCase();
+}
+
+/**
+ *
+ * @param {string} word
+ * @returns {string}
+ */
+function errorVowels(word: string): string {
+  return word.toLowerCase().replace(/[aeiou]/g, '*');
+}


### PR DESCRIPTION
# Title

Vowel Spellchecker

# Topic

Strings

# Description

Given a wordlist, we want to implement a spellchecker that converts a query word into a correct word.

For a given query word, the spell checker handles two categories of spelling mistakes:

- Capitalization: If the query matches a word in the wordlist (case-insensitive), then the query word is returned with the same case as the case in the wordlist.
  - Example: wordlist = ["yellow"], query = "YellOw": correct = "yellow"
  - Example: wordlist = ["Yellow"], query = "yellow": correct = "Yellow"
  - Example: wordlist = ["yellow"], query = "yellow": correct = "yellow"
- Vowel Errors: If after replacing the vowels ('a', 'e', 'i', 'o', 'u') of the query word with any vowel individually, it matches a word in the wordlist (case-insensitive), then the query word is returned with the same case as the match in the wordlist.
  - Example: wordlist = ["YellOw"], query = "yollow": correct = "YellOw"
  - Example: wordlist = ["YellOw"], query = "yeellow": correct = "" (no match)
  - Example: wordlist = ["YellOw"], query = "yllw": correct = "" (no match)

In addition, the spell checker operates under the following precedence rules:

- When the query exactly matches a word in the wordlist (case-sensitive), you should return the same word back.
- When the query matches a word up to capitlization, you should return the first such match in the wordlist.
- When the query matches a word up to vowel errors, you should return the first such match in the wordlist.
- If the query has no matches in the wordlist, you should return the empty string.

Given some queries, return a list of words answer, where answer[i] is the correct word for query = queries[i].

# Checklist

## README

- [x] Follows [PROBLEM-TEMPLATE](https://github.com/saulmaldonado/ds-and-algorithms/blob/main/PROBLEM-TEMPLATE.md)

## Solutions

- [x] Go

- [x] Java

- [x] JavaScript

- [x] TypeScript
